### PR TITLE
chore: release as GA

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
     "product_documentation": "https://cloud.google.com/workflows/",
     "client_documentation": "https://googleapis.dev/python/workflows/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559729",
-    "release_level": "beta",
+    "release_level": "ga",
     "language": "python",
     "repo": "googleapis/python-workflows",
     "distribution_name": "google-cloud-workflows",

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Python Client for Cloud Workflows
 =================================================
 
-|beta| |pypi| |versions|
+|GA| |pypi| |versions|
 
 `Cloud Workflows API`_: Orchestrate and automateGoogle Cloud and HTTP-based
 API services with serverless workflows.
@@ -9,8 +9,8 @@ API services with serverless workflows.
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+.. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg
    :target: https://pypi.org/project/google-cloud-workflows/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-workflows.svg

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,7 +1,7 @@
 Python Client for Cloud Workflows
 =================================================
 
-|beta| |pypi| |versions|
+|GA| |pypi| |versions|
 
 `Cloud Workflows API`_: Orchestrate and automateGoogle Cloud and HTTP-based
 API services with serverless workflows.
@@ -9,8 +9,8 @@ API services with serverless workflows.
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+.. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg
    :target: https://pypi.org/project/google-cloud-workflows/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-workflows.svg

--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,11 @@ setuptools.setup(
     include_package_data=True,
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
-        "libcst >= 0.2.5",
         "proto-plus >= 1.4.0",
     ),
     python_requires=">=3.6",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Release-As: 1.0.0

Small cleanup to delete an unused dependency `libcst`. https://github.com/googleapis/python-workflows/search?q=libcst&type= 


[GA release template](https://github.com/googleapis/google-cloud-common/issues/287)
## Required 

- [x] 28 days elapsed since last beta release with new API surface
- [x] Server API is GA
- [x] Package API is stable, and we can commit to backward compatibility
- [x] All dependencies are GA
