### PR TITLE
chore: s.remove_staging_dirs() should only be called once

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -43,8 +43,6 @@ for library in s.get_staging_dirs(workflows_executions_default_version):
             ],
         )
 
-s.remove_staging_dirs()
-
 # move workflows after executions, since we want to use "workflows" for the name
 for library in s.get_staging_dirs(workflows_default_version):
     if library.parent.absolute() == 'workflows':


### PR DESCRIPTION
There is [an issue](https://github.com/googleapis/python-workflows/blob/master/owlbot.py#L46) in the `owlbot.py` file added in #50 in that [s.remove_staging_dirs()](https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L309) should only be called once after all the files are copied over.  [get_staging_dirs()](https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L280) will only return staging directories that exist.