### PR TITLE
fix: exclude docs and tests from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,11 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [package for package in setuptools.PEP420PackageFinder.find() if package.startswith('google')]
+packages = [
+    package
+    for package in setuptools.PEP420PackageFinder.find()
+    if package.startswith("google")
+]
 
 setuptools.setup(
     name="google-cloud-workflows",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
+packages = [package for package in setuptools.PEP420PackageFinder.find() if package.startswith('google')]
+
 setuptools.setup(
     name="google-cloud-workflows",
     version=version,
@@ -35,7 +37,7 @@ setuptools.setup(
     author_email="googleapis-packages@google.com",
     license="Apache 2.0",
     url="https://github.com/googleapis/python-workflows",
-    packages=setuptools.PEP420PackageFinder.find(),
+    packages=packages,
     namespace_packages=("google", "google.cloud"),
     platforms="Posix; MacOS X; Windows",
     include_package_data=True,


### PR DESCRIPTION
Currently, packages `tests` and `docs` are installed (because they are discovered as valid packages by `PEP420PackageFinder`), which can break user's code if they also use `test` as a location for their tests, due to package name conflict.

To reproduce - install this package from pypi, see that `tests` package is present in your venv's site-packages.
This change pretty much follows what other Google packages do, eg [here](https://github.com/googleapis/python-api-core/blob/master/setup.py#L66)

