### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ API services with serverless workflows.
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-workflows.svg
    :target: https://pypi.org/project/google-cloud-workflows/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-workflows.svg
@@ -80,4 +80,4 @@ Next Steps
    APIs that we cover.
 
 .. _Cloud Workflows API Product documentation:  https://cloud.google.com/workflows/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.