### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "workflows",
     "name_pretty": "Cloud Workflows",
     "product_documentation": "https://cloud.google.com/workflows/",
-    "client_documentation": "https://googleapis.dev/python/workflows/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/workflows/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559729",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ API services with serverless workflows.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-workflows.svg
    :target: https://pypi.org/project/google-cloud-workflows/
 .. _Cloud Workflows API: https://cloud.google.com/workflows/docs
-.. _Client Library Documentation: https://googleapis.dev/python/workflows/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/workflows/latest
 .. _Product Documentation:  https://cloud.google.com/workflows/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.