### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-### [1.6.2](https://github.com/googleapis/python-workflows/compare/v1.6.1...v1.6.2) (2022-05-05)
+## [1.6.2](https://github.com/googleapis/python-workflows/compare/v1.6.1...v1.6.2) (2022-05-05)
 
 
 ### Documentation
 
 * fix type in docstring for map fields ([f3ec9da](https://github.com/googleapis/python-workflows/commit/f3ec9dadea8a3574a5413c635288242014b1a5ae))
 
-### [1.6.1](https://github.com/googleapis/python-workflows/compare/v1.6.0...v1.6.1) (2022-03-05)
+## [1.6.1](https://github.com/googleapis/python-workflows/compare/v1.6.0...v1.6.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -36,7 +36,7 @@
 * add a stack_trace field to the Error messages specifying where the error occurred ([#113](https://www.github.com/googleapis/python-workflows/issues/113)) ([22f55d3](https://www.github.com/googleapis/python-workflows/commit/22f55d30c57d31bf8d0839bd7289e1392ff65a18))
 * add call_log_level field to Execution messages ([22f55d3](https://www.github.com/googleapis/python-workflows/commit/22f55d30c57d31bf8d0839bd7289e1392ff65a18))
 
-### [1.4.1](https://www.github.com/googleapis/python-workflows/compare/v1.4.0...v1.4.1) (2021-11-01)
+## [1.4.1](https://www.github.com/googleapis/python-workflows/compare/v1.4.0...v1.4.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -63,21 +63,21 @@
 
 * add context manager support in client ([#102](https://www.github.com/googleapis/python-workflows/issues/102)) ([090c723](https://www.github.com/googleapis/python-workflows/commit/090c723e249c62fa29a519fd1aebdf205d12b03e))
 
-### [1.2.3](https://www.github.com/googleapis/python-workflows/compare/v1.2.2...v1.2.3) (2021-09-30)
+## [1.2.3](https://www.github.com/googleapis/python-workflows/compare/v1.2.2...v1.2.3) (2021-09-30)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([f33a1b9](https://www.github.com/googleapis/python-workflows/commit/f33a1b902c6d66222b2bd217f81f42188de24e65))
 
-### [1.2.2](https://www.github.com/googleapis/python-workflows/compare/v1.2.1...v1.2.2) (2021-09-24)
+## [1.2.2](https://www.github.com/googleapis/python-workflows/compare/v1.2.1...v1.2.2) (2021-09-24)
 
 
 ### Bug Fixes
 
 * add 'dict' annotation type to 'request' ([8e778a3](https://www.github.com/googleapis/python-workflows/commit/8e778a39b1a655867d129df4dbd573ac4763cd19))
 
-### [1.2.1](https://www.github.com/googleapis/python-workflows/compare/v1.2.0...v1.2.1) (2021-07-26)
+## [1.2.1](https://www.github.com/googleapis/python-workflows/compare/v1.2.0...v1.2.1) (2021-07-26)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.