### PR TITLE
chore: prepare for monorepo migration

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -20,9 +20,9 @@ deep-remove-regex:
 
 deep-copy-regex:
   - source: /google/cloud/workflows/executions/(v.*)/.*-py/(.*)
-    dest: /owl-bot-staging/executions/$1/$2
+    dest: /owl-bot-staging/$1/$2
   - source: /google/cloud/workflows/(v.*)/.*-py/(.*)
-    dest: /owl-bot-staging/workflows/$1/$2
+    dest: /owl-bot-staging/$1/$2
 
 begin-after-commit-hash: acb4b773a6df45f9303067ffcb21387a7b6ad40d
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,9 +12,7 @@ API Reference
     :maxdepth: 2
 
     workflows_v1/services
-    executions_v1/services
     workflows_v1/types
-    executions_v1/types
 
 API Reference
 -------------
@@ -22,9 +20,7 @@ API Reference
     :maxdepth: 2
 
     workflows_v1beta/services
-    executions_v1beta/services
     workflows_v1beta/types
-    executions_v1beta/types
 
 
 Changelog

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,9 @@ API Reference
     :maxdepth: 2
 
     workflows_v1/services
+    executions_v1/services
     workflows_v1/types
+    executions_v1/types
 
 API Reference
 -------------
@@ -20,7 +22,9 @@ API Reference
     :maxdepth: 2
 
     workflows_v1beta/services
+    executions_v1beta/services
     workflows_v1beta/types
+    executions_v1beta/types
 
 
 Changelog

--- a/owlbot.py
+++ b/owlbot.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-from typing import List, Optional
 from pathlib import Path
 import shutil
 
@@ -32,61 +31,12 @@ default_version = json.load(open(".repo-metadata.json", "rt")).get(
     "default_version"
 )
 
-# This is a customized version of the s.get_staging_dirs() function from synthtool to
-# cater for copying 2 different folders from googleapis-gen
-# which are workflows and workflows/executions
-# Source https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L280
-def get_staging_dirs(
-    default_version: Optional[str] = None, sub_directory: Optional[str] = None
-) -> List[Path]:
-    """Returns the list of directories, one per version, copied from
-    https://github.com/googleapis/googleapis-gen. Will return in lexical sorting
-    order with the exception of the default_version which will be last (if specified).
-
-    Args:
-      default_version (str): the default version of the API. The directory for this version
-        will be the last item in the returned list if specified.
-      sub_directory (str): if a `sub_directory` is provided, only the directories within the
-        specified `sub_directory` will be returned.
-
-    Returns: the empty list if no file were copied.
-    """
-
-    staging = Path("owl-bot-staging")
-
-    if sub_directory:
-        staging /= sub_directory
-
-    if staging.is_dir():
-        # Collect the subdirectories of the staging directory.
-        versions = [v.name for v in staging.iterdir() if v.is_dir()]
-        # Reorder the versions so the default version always comes last.
-        versions = [v for v in versions if v != default_version]
-        versions.sort()
-        if default_version is not None:
-            versions += [default_version]
-        dirs = [staging / v for v in versions]
-        for dir in dirs:
-            s._tracked_paths.add(dir)
-        return dirs
-    else:
-        return []
-
-
-for library in get_staging_dirs(default_version, "executions"):
-    # Make sure this library is named 'google-cloud-workflows'
-    s.replace(
-        library / "google/**/*.py", "google-cloud-workflows-executions", "google-cloud-workflows"
-    )
-    s.move([library], excludes=["**/gapic_version.py", "docs/index.rst"])
-
-# move workflows after executions, since we want to use "workflows" for the name
-for library in get_staging_dirs(default_version, "workflows"):
+for library in s.get_staging_dirs(default_version):
     if clean_up_generated_samples:
         shutil.rmtree("samples/generated_samples", ignore_errors=True)
         clean_up_generated_samples = False
-    s.move([library], excludes=["**/gapic_version.py", "docs/index.rst"])
 
+    s.move([library], excludes=["**/gapic_version.py"])
 s.remove_staging_dirs()
 
 # ----------------------------------------------------------------------------
@@ -98,7 +48,7 @@ templated_files = gcp.CommonTemplates().py_library(
     microgenerator=True,
     versions=gcp.common.detect_versions(path="./google", default_first=True),
 )
-s.move(templated_files, excludes=[".coveragerc", ".github/release-please.yml", "docs/index.rst"])
+s.move(templated_files, excludes=[".coveragerc", ".github/release-please.yml"])
 
 python.py_samples(skip_readmes=True)
 

--- a/samples/generated_samples/snippet_metadata_google.cloud.workflows.executions.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.cloud.workflows.executions.v1.json
@@ -1,0 +1,667 @@
+{
+  "clientLibrary": {
+    "apis": [
+      {
+        "id": "google.cloud.workflows.executions.v1",
+        "version": "v1"
+      }
+    ],
+    "language": "PYTHON",
+    "name": "google-cloud-workflows-executions",
+    "version": "0.1.0"
+  },
+  "snippets": [
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1.ExecutionsAsyncClient",
+          "shortName": "ExecutionsAsyncClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1.ExecutionsAsyncClient.cancel_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1.Executions.CancelExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "CancelExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1.types.CancelExecutionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1.types.Execution",
+        "shortName": "cancel_execution"
+      },
+      "description": "Sample for CancelExecution",
+      "file": "workflowexecutions_v1_generated_executions_cancel_execution_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1_generated_Executions_CancelExecution_async",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1_generated_executions_cancel_execution_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1.ExecutionsClient",
+          "shortName": "ExecutionsClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1.ExecutionsClient.cancel_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1.Executions.CancelExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "CancelExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1.types.CancelExecutionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1.types.Execution",
+        "shortName": "cancel_execution"
+      },
+      "description": "Sample for CancelExecution",
+      "file": "workflowexecutions_v1_generated_executions_cancel_execution_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1_generated_Executions_CancelExecution_sync",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1_generated_executions_cancel_execution_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1.ExecutionsAsyncClient",
+          "shortName": "ExecutionsAsyncClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1.ExecutionsAsyncClient.create_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1.Executions.CreateExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "CreateExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1.types.CreateExecutionRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "execution",
+            "type": "google.cloud.workflows.executions_v1.types.Execution"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1.types.Execution",
+        "shortName": "create_execution"
+      },
+      "description": "Sample for CreateExecution",
+      "file": "workflowexecutions_v1_generated_executions_create_execution_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1_generated_Executions_CreateExecution_async",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1_generated_executions_create_execution_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1.ExecutionsClient",
+          "shortName": "ExecutionsClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1.ExecutionsClient.create_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1.Executions.CreateExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "CreateExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1.types.CreateExecutionRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "execution",
+            "type": "google.cloud.workflows.executions_v1.types.Execution"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1.types.Execution",
+        "shortName": "create_execution"
+      },
+      "description": "Sample for CreateExecution",
+      "file": "workflowexecutions_v1_generated_executions_create_execution_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1_generated_Executions_CreateExecution_sync",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1_generated_executions_create_execution_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1.ExecutionsAsyncClient",
+          "shortName": "ExecutionsAsyncClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1.ExecutionsAsyncClient.get_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1.Executions.GetExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "GetExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1.types.GetExecutionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1.types.Execution",
+        "shortName": "get_execution"
+      },
+      "description": "Sample for GetExecution",
+      "file": "workflowexecutions_v1_generated_executions_get_execution_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1_generated_Executions_GetExecution_async",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1_generated_executions_get_execution_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1.ExecutionsClient",
+          "shortName": "ExecutionsClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1.ExecutionsClient.get_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1.Executions.GetExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "GetExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1.types.GetExecutionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1.types.Execution",
+        "shortName": "get_execution"
+      },
+      "description": "Sample for GetExecution",
+      "file": "workflowexecutions_v1_generated_executions_get_execution_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1_generated_Executions_GetExecution_sync",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1_generated_executions_get_execution_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1.ExecutionsAsyncClient",
+          "shortName": "ExecutionsAsyncClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1.ExecutionsAsyncClient.list_executions",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1.Executions.ListExecutions",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "ListExecutions"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1.types.ListExecutionsRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1.services.executions.pagers.ListExecutionsAsyncPager",
+        "shortName": "list_executions"
+      },
+      "description": "Sample for ListExecutions",
+      "file": "workflowexecutions_v1_generated_executions_list_executions_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1_generated_Executions_ListExecutions_async",
+      "segments": [
+        {
+          "end": 52,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 52,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 53,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1_generated_executions_list_executions_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1.ExecutionsClient",
+          "shortName": "ExecutionsClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1.ExecutionsClient.list_executions",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1.Executions.ListExecutions",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "ListExecutions"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1.types.ListExecutionsRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1.services.executions.pagers.ListExecutionsPager",
+        "shortName": "list_executions"
+      },
+      "description": "Sample for ListExecutions",
+      "file": "workflowexecutions_v1_generated_executions_list_executions_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1_generated_Executions_ListExecutions_sync",
+      "segments": [
+        {
+          "end": 52,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 52,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 53,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1_generated_executions_list_executions_sync.py"
+    }
+  ]
+}

--- a/samples/generated_samples/snippet_metadata_google.cloud.workflows.executions.v1beta.json
+++ b/samples/generated_samples/snippet_metadata_google.cloud.workflows.executions.v1beta.json
@@ -1,0 +1,667 @@
+{
+  "clientLibrary": {
+    "apis": [
+      {
+        "id": "google.cloud.workflows.executions.v1beta",
+        "version": "v1beta"
+      }
+    ],
+    "language": "PYTHON",
+    "name": "google-cloud-workflows-executions",
+    "version": "0.1.0"
+  },
+  "snippets": [
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsAsyncClient",
+          "shortName": "ExecutionsAsyncClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsAsyncClient.cancel_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1beta.Executions.CancelExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1beta.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "CancelExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1beta.types.CancelExecutionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1beta.types.Execution",
+        "shortName": "cancel_execution"
+      },
+      "description": "Sample for CancelExecution",
+      "file": "workflowexecutions_v1beta_generated_executions_cancel_execution_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1beta_generated_Executions_CancelExecution_async",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1beta_generated_executions_cancel_execution_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsClient",
+          "shortName": "ExecutionsClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsClient.cancel_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1beta.Executions.CancelExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1beta.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "CancelExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1beta.types.CancelExecutionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1beta.types.Execution",
+        "shortName": "cancel_execution"
+      },
+      "description": "Sample for CancelExecution",
+      "file": "workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1beta_generated_Executions_CancelExecution_sync",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsAsyncClient",
+          "shortName": "ExecutionsAsyncClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsAsyncClient.create_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1beta.Executions.CreateExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1beta.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "CreateExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1beta.types.CreateExecutionRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "execution",
+            "type": "google.cloud.workflows.executions_v1beta.types.Execution"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1beta.types.Execution",
+        "shortName": "create_execution"
+      },
+      "description": "Sample for CreateExecution",
+      "file": "workflowexecutions_v1beta_generated_executions_create_execution_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1beta_generated_Executions_CreateExecution_async",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1beta_generated_executions_create_execution_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsClient",
+          "shortName": "ExecutionsClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsClient.create_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1beta.Executions.CreateExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1beta.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "CreateExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1beta.types.CreateExecutionRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "execution",
+            "type": "google.cloud.workflows.executions_v1beta.types.Execution"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1beta.types.Execution",
+        "shortName": "create_execution"
+      },
+      "description": "Sample for CreateExecution",
+      "file": "workflowexecutions_v1beta_generated_executions_create_execution_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1beta_generated_Executions_CreateExecution_sync",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1beta_generated_executions_create_execution_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsAsyncClient",
+          "shortName": "ExecutionsAsyncClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsAsyncClient.get_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1beta.Executions.GetExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1beta.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "GetExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1beta.types.GetExecutionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1beta.types.Execution",
+        "shortName": "get_execution"
+      },
+      "description": "Sample for GetExecution",
+      "file": "workflowexecutions_v1beta_generated_executions_get_execution_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1beta_generated_Executions_GetExecution_async",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1beta_generated_executions_get_execution_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsClient",
+          "shortName": "ExecutionsClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsClient.get_execution",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1beta.Executions.GetExecution",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1beta.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "GetExecution"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1beta.types.GetExecutionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1beta.types.Execution",
+        "shortName": "get_execution"
+      },
+      "description": "Sample for GetExecution",
+      "file": "workflowexecutions_v1beta_generated_executions_get_execution_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1beta_generated_Executions_GetExecution_sync",
+      "segments": [
+        {
+          "end": 51,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 51,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 52,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1beta_generated_executions_get_execution_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsAsyncClient",
+          "shortName": "ExecutionsAsyncClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsAsyncClient.list_executions",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1beta.Executions.ListExecutions",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1beta.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "ListExecutions"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1beta.types.ListExecutionsRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1beta.services.executions.pagers.ListExecutionsAsyncPager",
+        "shortName": "list_executions"
+      },
+      "description": "Sample for ListExecutions",
+      "file": "workflowexecutions_v1beta_generated_executions_list_executions_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1beta_generated_Executions_ListExecutions_async",
+      "segments": [
+        {
+          "end": 52,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 52,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 53,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1beta_generated_executions_list_executions_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsClient",
+          "shortName": "ExecutionsClient"
+        },
+        "fullName": "google.cloud.workflows.executions_v1beta.ExecutionsClient.list_executions",
+        "method": {
+          "fullName": "google.cloud.workflows.executions.v1beta.Executions.ListExecutions",
+          "service": {
+            "fullName": "google.cloud.workflows.executions.v1beta.Executions",
+            "shortName": "Executions"
+          },
+          "shortName": "ListExecutions"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.workflows.executions_v1beta.types.ListExecutionsRequest"
+          },
+          {
+            "name": "parent",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.workflows.executions_v1beta.services.executions.pagers.ListExecutionsPager",
+        "shortName": "list_executions"
+      },
+      "description": "Sample for ListExecutions",
+      "file": "workflowexecutions_v1beta_generated_executions_list_executions_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "workflowexecutions_v1beta_generated_Executions_ListExecutions_sync",
+      "segments": [
+        {
+          "end": 52,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 52,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 53,
+          "start": 49,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "workflowexecutions_v1beta_generated_executions_list_executions_sync.py"
+    }
+  ]
+}

--- a/samples/generated_samples/snippet_metadata_google.cloud.workflows.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.cloud.workflows.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-workflows",
-    "version": "1.10.1"
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/samples/generated_samples/snippet_metadata_google.cloud.workflows.v1beta.json
+++ b/samples/generated_samples/snippet_metadata_google.cloud.workflows.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-workflows",
-    "version": "1.10.1"
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_async.py
+++ b/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CancelExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1_generated_Executions_CancelExecution_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1
+
+
+async def sample_cancel_execution():
+    # Create a client
+    client = executions_v1.ExecutionsAsyncClient()
+
+    # Initialize request argument(s)
+    request = executions_v1.CancelExecutionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.cancel_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1_generated_Executions_CancelExecution_async]

--- a/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_sync.py
+++ b/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CancelExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1_generated_Executions_CancelExecution_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1
+
+
+def sample_cancel_execution():
+    # Create a client
+    client = executions_v1.ExecutionsClient()
+
+    # Initialize request argument(s)
+    request = executions_v1.CancelExecutionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.cancel_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1_generated_Executions_CancelExecution_sync]

--- a/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_async.py
+++ b/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1_generated_Executions_CreateExecution_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1
+
+
+async def sample_create_execution():
+    # Create a client
+    client = executions_v1.ExecutionsAsyncClient()
+
+    # Initialize request argument(s)
+    request = executions_v1.CreateExecutionRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    response = await client.create_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1_generated_Executions_CreateExecution_async]

--- a/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_sync.py
+++ b/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1_generated_Executions_CreateExecution_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1
+
+
+def sample_create_execution():
+    # Create a client
+    client = executions_v1.ExecutionsClient()
+
+    # Initialize request argument(s)
+    request = executions_v1.CreateExecutionRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    response = client.create_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1_generated_Executions_CreateExecution_sync]

--- a/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_async.py
+++ b/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1_generated_Executions_GetExecution_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1
+
+
+async def sample_get_execution():
+    # Create a client
+    client = executions_v1.ExecutionsAsyncClient()
+
+    # Initialize request argument(s)
+    request = executions_v1.GetExecutionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.get_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1_generated_Executions_GetExecution_async]

--- a/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_sync.py
+++ b/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1_generated_Executions_GetExecution_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1
+
+
+def sample_get_execution():
+    # Create a client
+    client = executions_v1.ExecutionsClient()
+
+    # Initialize request argument(s)
+    request = executions_v1.GetExecutionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.get_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1_generated_Executions_GetExecution_sync]

--- a/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_async.py
+++ b/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_async.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListExecutions
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1_generated_Executions_ListExecutions_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1
+
+
+async def sample_list_executions():
+    # Create a client
+    client = executions_v1.ExecutionsAsyncClient()
+
+    # Initialize request argument(s)
+    request = executions_v1.ListExecutionsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_executions(request=request)
+
+    # Handle the response
+    async for response in page_result:
+        print(response)
+
+# [END workflowexecutions_v1_generated_Executions_ListExecutions_async]

--- a/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_sync.py
+++ b/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_sync.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListExecutions
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1_generated_Executions_ListExecutions_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1
+
+
+def sample_list_executions():
+    # Create a client
+    client = executions_v1.ExecutionsClient()
+
+    # Initialize request argument(s)
+    request = executions_v1.ListExecutionsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_executions(request=request)
+
+    # Handle the response
+    for response in page_result:
+        print(response)
+
+# [END workflowexecutions_v1_generated_Executions_ListExecutions_sync]

--- a/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_async.py
+++ b/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CancelExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1beta_generated_Executions_CancelExecution_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1beta
+
+
+async def sample_cancel_execution():
+    # Create a client
+    client = executions_v1beta.ExecutionsAsyncClient()
+
+    # Initialize request argument(s)
+    request = executions_v1beta.CancelExecutionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.cancel_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1beta_generated_Executions_CancelExecution_async]

--- a/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py
+++ b/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CancelExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1beta_generated_Executions_CancelExecution_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1beta
+
+
+def sample_cancel_execution():
+    # Create a client
+    client = executions_v1beta.ExecutionsClient()
+
+    # Initialize request argument(s)
+    request = executions_v1beta.CancelExecutionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.cancel_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1beta_generated_Executions_CancelExecution_sync]

--- a/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_async.py
+++ b/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1beta_generated_Executions_CreateExecution_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1beta
+
+
+async def sample_create_execution():
+    # Create a client
+    client = executions_v1beta.ExecutionsAsyncClient()
+
+    # Initialize request argument(s)
+    request = executions_v1beta.CreateExecutionRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    response = await client.create_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1beta_generated_Executions_CreateExecution_async]

--- a/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_sync.py
+++ b/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1beta_generated_Executions_CreateExecution_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1beta
+
+
+def sample_create_execution():
+    # Create a client
+    client = executions_v1beta.ExecutionsClient()
+
+    # Initialize request argument(s)
+    request = executions_v1beta.CreateExecutionRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    response = client.create_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1beta_generated_Executions_CreateExecution_sync]

--- a/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_async.py
+++ b/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1beta_generated_Executions_GetExecution_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1beta
+
+
+async def sample_get_execution():
+    # Create a client
+    client = executions_v1beta.ExecutionsAsyncClient()
+
+    # Initialize request argument(s)
+    request = executions_v1beta.GetExecutionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.get_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1beta_generated_Executions_GetExecution_async]

--- a/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_sync.py
+++ b/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetExecution
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1beta_generated_Executions_GetExecution_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1beta
+
+
+def sample_get_execution():
+    # Create a client
+    client = executions_v1beta.ExecutionsClient()
+
+    # Initialize request argument(s)
+    request = executions_v1beta.GetExecutionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.get_execution(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END workflowexecutions_v1beta_generated_Executions_GetExecution_sync]

--- a/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_async.py
+++ b/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_async.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListExecutions
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1beta_generated_Executions_ListExecutions_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1beta
+
+
+async def sample_list_executions():
+    # Create a client
+    client = executions_v1beta.ExecutionsAsyncClient()
+
+    # Initialize request argument(s)
+    request = executions_v1beta.ListExecutionsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_executions(request=request)
+
+    # Handle the response
+    async for response in page_result:
+        print(response)
+
+# [END workflowexecutions_v1beta_generated_Executions_ListExecutions_async]

--- a/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_sync.py
+++ b/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_sync.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListExecutions
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-workflows-executions
+
+
+# [START workflowexecutions_v1beta_generated_Executions_ListExecutions_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud.workflows import executions_v1beta
+
+
+def sample_list_executions():
+    # Create a client
+    client = executions_v1beta.ExecutionsClient()
+
+    # Initialize request argument(s)
+    request = executions_v1beta.ListExecutionsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_executions(request=request)
+
+    # Handle the response
+    for response in page_result:
+        print(response)
+
+# [END workflowexecutions_v1beta_generated_Executions_ListExecutions_sync]


### PR DESCRIPTION
This PR migrates to a standard owlbot.py file, instead of a customized one. This will require manual changes to `docs/index.rst`. Presubmits will fail with the standard `docs/index.rst` file.

Background
-----

The repository googleapis/python-workflows contains code for 2 APIs google/cloud/workflows and google/cloud/workflows/executions

See
https://github.com/googleapis/googleapis/tree/master/google/cloud/workflows and https://github.com/googleapis/googleapis/tree/master/google/cloud/workflows/executions

The samples for `google/cloud/workflows/executions` do not exist in https://github.com/googleapis/python-workflows/tree/main/samples/generated_samples. 

The PR is removing custom logic in owlbot.py, and making the necessary changes in `.Owlbot.yaml` instead.

As a result, autogenerated samples are being generated for  `google/cloud/workflows/executions`.